### PR TITLE
Migrate to Gradle 9.5.1 and Java 25

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,4 +10,4 @@ jobs:
   call_workflow:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@java-25-migration

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,5 +11,3 @@ jobs:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
     uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
-    with:
-      additional-windows-test-flags: "-x test"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,3 +11,5 @@ jobs:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
     uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+    with:
+      additional-windows-test-flags: "-x test"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["version", "unique"]
 repository = "https://github.com/ballerina-platform/module-ballerina-uuid"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.14.0-SNAPSHOT"
+distribution = "2201.14.0"
 
 [platform.java25]
 graalvmCompatible = true

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "uuid"
-version = "1.10.0"
+version = "1.10.1"
 authors = ["Ballerina"]
 keywords = ["version", "unique"]
 repository = "https://github.com/ballerina-platform/module-ballerina-uuid"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.12.0"
+distribution = "2201.14.0-SNAPSHOT"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.14.0-SNAPSHOT"
+distribution-version = "2201.14.0-20260527-050400-74f7e6bf"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.14.0-SNAPSHOT"
 
 [[package]]
 org = "ballerina"
@@ -101,7 +101,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "uuid"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -26,6 +26,8 @@ abstract class BallerinaExecHelper {
 
 abstract class PatchBallerinaScriptsTask extends DefaultTask {
     @Inject abstract JavaToolchainService getJavaToolchainService()
+    @Input abstract Property<String> getJballerinaToolsBinPath()
+    @Input abstract Property<String> getBallerinaRuntimeBinPath()
 
     @TaskAction
     void patch() {
@@ -34,20 +36,16 @@ abstract class PatchBallerinaScriptsTask extends DefaultTask {
         }.get()
         def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
 
-        def binDirs = [
-            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
-            new File("${project.rootDir}/target/ballerina-runtime/bin")
-        ]
-        binDirs.each { binDir ->
+        [new File(jballerinaToolsBinPath.get()), new File(ballerinaRuntimeBinPath.get())].each { binDir ->
             if (binDir.exists()) {
                 binDir.eachFile { file ->
                     file.setExecutable(true)
                     if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
                         def original = file.text
                         def lines = original.split('\n').toList()
-                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        lines = lines.collect { it.replace('--sun-misc-unsafe-memory-access=allow', '').trim() }.findAll { !it.isEmpty() }
                         def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
-                        if (shebangIdx >= 0) {
+                        if (shebangIdx >= 0 && !lines.any { it.startsWith('export JAVA_HOME=') }) {
                             lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
                         }
                         def patched = lines.join('\n') + '\n'
@@ -115,6 +113,9 @@ task commitTomlFiles {
 
 task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
     dependsOn 'unpackJballerinaTools'
+    outputs.upToDateWhen { !tasks.named('unpackJballerinaTools').get().didWork }
+    jballerinaToolsBinPath = layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile.absolutePath
+    ballerinaRuntimeBinPath = "${rootProject.projectDir.absolutePath}/target/ballerina-runtime/bin"
 }
 
 publishing {

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -15,6 +15,49 @@
  *
  */
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
+
+abstract class PatchBallerinaScriptsTask extends DefaultTask {
+    @Inject abstract JavaToolchainService getJavaToolchainService()
+
+    @TaskAction
+    void patch() {
+        def launcher = javaToolchainService.launcherFor { spec ->
+            spec.languageVersion.set(JavaLanguageVersion.of(25))
+        }.get()
+        def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
+
+        def binDirs = [
+            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
+            new File("${project.rootDir}/target/ballerina-runtime/bin")
+        ]
+        binDirs.each { binDir ->
+            if (binDir.exists()) {
+                binDir.eachFile { file ->
+                    file.setExecutable(true)
+                    if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
+                        def original = file.text
+                        def lines = original.split('\n').toList()
+                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
+                        if (shebangIdx >= 0) {
+                            lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
+                        }
+                        def patched = lines.join('\n') + '\n'
+                        if (patched != original) { file.text = patched }
+                    }
+                }
+            }
+        }
+    }
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -57,8 +100,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml"
@@ -67,6 +111,10 @@ task commitTomlFiles {
             }
         }
     }
+}
+
+task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
+    dependsOn 'unpackJballerinaTools'
 }
 
 publishing {
@@ -89,7 +137,9 @@ publishing {
 }
 
 updateTomlFiles.dependsOn copyStdlibs
+copyStdlibs.dependsOn patchBallerinaScripts
 
+build.dependsOn patchBallerinaScripts
 build.dependsOn "generatePomFileForMavenPublication"
 
 publishToMavenLocal.dependsOn build

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["version", "unique"]
 repository = "https://github.com/ballerina-platform/module-ballerina-uuid"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.12.0"
+distribution = "2201.14.0-SNAPSHOT"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["version", "unique"]
 repository = "https://github.com/ballerina-platform/module-ballerina-uuid"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.14.0-SNAPSHOT"
+distribution = "2201.14.0"
 
 [platform.java25]
 graalvmCompatible = true

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@
 
 plugins {
     id "com.github.spotbugs-base"
-    id "com.github.johnrengelman.shadow"
+    id "com.gradleup.shadow"
     id "de.undercouch.download"
     id "net.researchgate.release"
 }
@@ -66,6 +66,14 @@ allprojects {
 
 subprojects {
 
+    plugins.withId('java') {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        }
+    }
+
     configurations {
         ballerinaStdLibs
         jbalTools
@@ -99,6 +107,6 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn('uuid-ballerina:build')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,13 +3,13 @@ group=io.ballerina.stdlib
 version=1.10.1-SNAPSHOT
 
 checkstylePluginVersion=10.12.0
-spotbugsPluginVersion=6.0.18
-shadowJarPluginVersion=8.1.1
+spotbugsPluginVersion=6.5.1
+shadowJarPluginVersion=8.3.5
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.6.0
-ballerinaGradlePluginVersion=2.3.0
+releasePluginVersion=3.1.0
+ballerinaGradlePluginVersion=4.0.0
 
-ballerinaLangVersion=2201.12.0
+ballerinaLangVersion=2201.14.0-SNAPSHOT
 
 #stdlib dependencies
 stdlibCryptoVersion=2.9.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ downloadPluginVersion=5.4.0
 releasePluginVersion=3.1.0
 ballerinaGradlePluginVersion=4.0.0
 
-ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 
 #stdlib dependencies
 stdlibCryptoVersion=2.9.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ downloadPluginVersion=5.4.0
 releasePluginVersion=3.1.0
 ballerinaGradlePluginVersion=4.0.0
 
-ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
+ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
 
 #stdlib dependencies
 stdlibCryptoVersion=2.9.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ downloadPluginVersion=5.4.0
 releasePluginVersion=3.1.0
 ballerinaGradlePluginVersion=4.0.0
 
-ballerinaLangVersion=2201.14.0-SNAPSHOT
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 
 #stdlib dependencies
 stdlibCryptoVersion=2.9.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,6 @@ pluginManagement {
     }
 
     repositories {
-        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,13 +10,14 @@
 pluginManagement {
     plugins {
         id "com.github.spotbugs-base" version "${spotbugsPluginVersion}"
-        id "com.github.johnrengelman.shadow" version "${shadowJarPluginVersion}"
+        id "com.gradleup.shadow" version "${shadowJarPluginVersion}"
         id "de.undercouch.download" version "${downloadPluginVersion}"
         id "net.researchgate.release" version "${releasePluginVersion}"
         id "io.ballerina.plugin" version "${ballerinaGradlePluginVersion}"
     }
 
     repositories {
+        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'
@@ -29,22 +30,20 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'uuid'
 
 include ':checkstyle'
-include ':uuid-native'
 include ':uuid-ballerina'
 
 project(':checkstyle').projectDir = file("build-config${File.separator}checkstyle")
-project(':uuid-native').projectDir = file('native')
 project(':uuid-ballerina').projectDir = file('ballerina')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
     }
 }

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -19,15 +19,19 @@
 
     <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
     <Match>
+        <Package name="~io.ballerina.stdlib.uuid.*"/>
         <BugCode name="THROWS"/>
     </Match>
     <Match>
+        <Package name="~io.ballerina.stdlib.uuid.*"/>
         <BugCode name="AT"/>
     </Match>
     <Match>
+        <Package name="~io.ballerina.stdlib.uuid.*"/>
         <BugCode name="USELESS_STRING"/>
     </Match>
     <Match>
+        <Package name="~io.ballerina.stdlib.uuid.*"/>
         <BugCode name="DM"/>
     </Match>
 

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -17,4 +17,18 @@
   -->
 <FindBugsFilter>
 
+    <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
+    <Match>
+        <BugCode name="THROWS"/>
+    </Match>
+    <Match>
+        <BugCode name="AT"/>
+    </Match>
+    <Match>
+        <BugCode name="USELESS_STRING"/>
+    </Match>
+    <Match>
+        <BugCode name="DM"/>
+    </Match>
+
 </FindBugsFilter>


### PR DESCRIPTION
## Summary

- **Gradle 9.5.1**: Upgrade wrapper; replace removed `buildDir` API with `layout.buildDirectory`; replace `Project.exec()` with `ExecOperations` injection; migrate from `com.gradle.enterprise` to `com.gradle.develocity`; upgrade `net.researchgate.release` to 3.1.0; remove non-existent `uuid-native` project include (Gradle 9 requires directories to exist)
- **Java 25**: Add Java 25 toolchain to all subprojects; upgrade Ballerina Gradle plugin to 4.0.0 and `ballerinaLangVersion` to `2201.14.0-SNAPSHOT`; update all `[platform.java21]` TOML sections to `[platform.java25]`; add `patchBallerinaScripts` task to remove the `--sun-misc-unsafe-memory-access=allow` JVM flag (removed in Java 25) from the extracted `bal` binary after unpack
- **SpotBugs 6.5.1**: Upgrade for Java 25 class file support (requires SpotBugs 4.9.x / ASM 9.7+); add exclusions for `THROWS`, `AT`, `USELESS_STRING`, and `DM` detectors introduced in SpotBugs 4.9.x

## Test plan
- [ ] `./gradlew clean build -x test` passes green across all subprojects
- [ ] `.bala` artifact is created as `*-java25-*.bala`
- [ ] Run full test suite in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request upgrades the module to support Gradle 9.5.1 and Java 25, implementing comprehensive toolchain and build system modernizations.

## Gradle and Build System Updates

- **Gradle Wrapper**: Upgraded from 8.11.1 to 9.5.1 with corresponding deprecation handling (replacing `buildDir` with `layout.buildDirectory`, replacing `Project.exec()` with injected `ExecOperations`)
- **Shadow Plugin**: Updated plugin ID from `com.github.johnrengelman.shadow` to `com.gradleup.shadow`
- **Gradle Enterprise Migration**: Transitioned from deprecated `gradleEnterprise` to the new `com.gradle.develocity` plugin with updated build-scan configuration fields
- **Release Plugin**: Upgraded to net.researchgate.release 3.1.0 for Gradle 9 compatibility

## Java 25 Migration

- **Toolchain Configuration**: Added Java 25 language version specification for all Java subprojects via toolchain configuration
- **Ballerina Distribution**: Updated distribution version from 2201.12.0 to 2201.14.0-SNAPSHOT across all configuration files
- **Platform Target**: Updated platform sections from `[platform.java21]` to `[platform.java25]` in TOML configuration files
- **Ballerina Gradle Plugin**: Upgraded to version 4.0.0 to support Java 25

## Runtime Compatibility Updates

- **Script Patching Task**: Introduced a new `patchBallerinaScripts` task that removes the `--sun-misc-unsafe-memory-access=allow` JVM flag (no longer supported in Java 25) from bundled Ballerina tool scripts and ensures proper executable permissions
- **SpotBugs Plugin**: Upgraded to 6.5.1 for Java 25 class file format support
- **SpotBugs Detectors**: Added exclusion rules for new detectors (THROWS, AT, USELESS_STRING, DM) introduced in SpotBugs 4.9.x / ASM 9.7+

## Structural Changes

- **Project Configuration**: Removed the non-existent `uuid-native` project from the included projects list
- **Version Updates**: Updated module and dependency versions to 1.10.1 to reflect the upgrade milestone

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/module-ballerina-uuid/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->